### PR TITLE
Switch off RPC calls

### DIFF
--- a/src/web3/providers.ts
+++ b/src/web3/providers.ts
@@ -3,7 +3,7 @@ import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { isPlain } from '@reduxjs/toolkit'
 
 import { ChainId, CHAINS } from './chains'
-import { AVERAGE_L1_BLOCK_TIME } from './chainInfo'
+//import { AVERAGE_L1_BLOCK_TIME } from './chainInfo'
 
 class AppJsonRpcProvider extends StaticJsonRpcProvider {
   private _blockCache = new Map<string, Promise<any>>()
@@ -17,7 +17,7 @@ class AppJsonRpcProvider extends StaticJsonRpcProvider {
   constructor(chainId: ChainId) {
     super(CHAINS[chainId].urls[0], { chainId, name: CHAINS[chainId].name })
 
-    this.pollingInterval = AVERAGE_L1_BLOCK_TIME
+    this.pollingInterval = 120000 // AVERAGE_L1_BLOCK_TIME
   }
 
   send(method: string, params: Array<any>): Promise<any> {


### PR DESCRIPTION
For now we will just let the timers execute once on page load and then switch themselves off; this should be easy to revert once the multicall implementation is being used.

The internal polling inside the ethers provider has also been slowed down; theoretically this should not impact anything other than the fetching of new blocks by ethers.